### PR TITLE
[Feature] get shortnames for serial ports

### DIFF
--- a/ESPEasySerialPort.cpp
+++ b/ESPEasySerialPort.cpp
@@ -1,30 +1,30 @@
 #include "ESPEasySerialPort.h"
 
-const __FlashStringHelper* ESPEasySerialPort_toString(ESPEasySerialPort port)
+const __FlashStringHelper* ESPEasySerialPort_toString(ESPEasySerialPort , bool shortName)
 {
   switch (port) {
     case ESPEasySerialPort::not_set:         break;
 #if USES_I2C_SC16IS752
-    case ESPEasySerialPort::sc16is752:       return F("I2C Serial");
+    case ESPEasySerialPort::sc16is752:       return shortName ? F("seriali2c") : F("I2C Serial");
 #endif // if USES_I2C_SC16IS752
 #ifdef ESP8266
-    case ESPEasySerialPort::serial0_swap:    return F("HW Serial0 swap");
+    case ESPEasySerialPort::serial0_swap:    return shortName ? F("serial0swap") : F("HW Serial0 swap");
 #endif // ifdef ESP8266
-    case ESPEasySerialPort::serial0:         return F("HW Serial0");
+    case ESPEasySerialPort::serial0:         return shortName ? F("serial0") : F("HW Serial0");
 #if SOC_UART_NUM > 1
-    case ESPEasySerialPort::serial1:         return F("HW Serial1");
+    case ESPEasySerialPort::serial1:         return shortName ? F("serial1") : F("HW Serial1");
 #endif // if SOC_UART_NUM > 1
 #if SOC_UART_NUM > 2
-    case ESPEasySerialPort::serial2:         return F("HW Serial2");
+    case ESPEasySerialPort::serial2:         return shortName ? F("serial2") : F("HW Serial2");
 #endif // if SOC_UART_NUM > 2
 #if USES_SW_SERIAL
-    case ESPEasySerialPort::software:        return F("SW Serial");
+    case ESPEasySerialPort::software:        return shortName ? F("serial") : F("SW Serial");
 #endif // if USES_SW_SERIAL
 #if USES_HWCDC
-    case ESPEasySerialPort::usb_hw_cdc:      return F("USB HWCDC");
+    case ESPEasySerialPort::usb_hw_cdc:      return shortName ? F("serialhwcdc") : F("USB HWCDC");
 #endif // if USES_HWCDC
 #if USES_USBCDC
-    case ESPEasySerialPort::usb_cdc_0:       return F("USB CDC");
+    case ESPEasySerialPort::usb_cdc_0:       return shortName ? F("serialcdc") : F("USB CDC");
 //    case ESPEasySerialPort::usb_cdc_1:       return F("USB CDC1");
 #endif // if USES_USBCDC
     case ESPEasySerialPort::MAX_SERIAL_TYPE: break;

--- a/ESPEasySerialPort.cpp
+++ b/ESPEasySerialPort.cpp
@@ -1,6 +1,6 @@
 #include "ESPEasySerialPort.h"
 
-const __FlashStringHelper* ESPEasySerialPort_toString(ESPEasySerialPort , bool shortName)
+const __FlashStringHelper* ESPEasySerialPort_toString(ESPEasySerialPort port, bool shortName)
 {
   switch (port) {
     case ESPEasySerialPort::not_set:         break;
@@ -18,7 +18,7 @@ const __FlashStringHelper* ESPEasySerialPort_toString(ESPEasySerialPort , bool s
     case ESPEasySerialPort::serial2:         return shortName ? F("serial2") : F("HW Serial2");
 #endif // if SOC_UART_NUM > 2
 #if USES_SW_SERIAL
-    case ESPEasySerialPort::software:        return shortName ? F("serial") : F("SW Serial");
+    case ESPEasySerialPort::software:        return shortName ? F("serialsw") : F("SW Serial");
 #endif // if USES_SW_SERIAL
 #if USES_HWCDC
     case ESPEasySerialPort::usb_hw_cdc:      return shortName ? F("serialhwcdc") : F("USB HWCDC");

--- a/ESPEasySerialPort.h
+++ b/ESPEasySerialPort.h
@@ -36,7 +36,7 @@ enum class ESPEasySerialPort : uint8_t {
 };
 
 
-const __FlashStringHelper* ESPEasySerialPort_toString(ESPEasySerialPort port);
+const __FlashStringHelper* ESPEasySerialPort_toString(ESPEasySerialPort port, bool shortName = false);
 
 bool                       isHWserial(ESPEasySerialPort port);
 


### PR DESCRIPTION
Feature:
- Get a short-name for a port, to be used as event name in ESPEasy